### PR TITLE
feat: expose session and headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,29 +27,6 @@ jobs:
       - name: 🔬 Lint
         run: yarn lint
 
-  typescript:
-    name: ʦ TypeScript
-    runs-on: ubuntu-latest
-    steps:
-      - name: 🛑 Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.9.1
-
-      - name: ⬇️ Checkout repo
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: ⎔ Setup node
-        uses: actions/setup-node@v3
-        with:
-          node-version: 16.13.0
-
-      - name: 📥 Download deps
-        uses: bahmutov/npm-install@v1
-
-      - name: 🔎 Type check
-        run: yarn type-check
-
   test:
     name: ⚡ Test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ yarn add remix-wizard
 ```
 
 ## Examples
+
 ### Basic
 
 1. Create a wizard and specify your `routes`
 
 **oboarding.server.ts**
+
 ```.ts
 export const onboardingWizard = createWizard({
   name: 'onboarding-wizard',
@@ -67,7 +69,8 @@ export const loader = async ({ request }) => {
 ```
 
 ### Use custom `SessionStorage`
-By default `remix-wizard` will use `createCookieSessionStorage` if you do not pass a `storage` paramter to the `createWizard` function. 
+
+By default `remix-wizard` will use `createCookieSessionStorage` if you do not pass a `storage` paramter to the `createWizard` function.
 
 But you can also use any other `SessionStorage` you wish.
 
@@ -83,4 +86,40 @@ export const onboardingWizard = createWizard({
   }),
 });
 
+```
+
+### Save session data without changing step
+
+Sometimes you may want to save data to the session without changing the wizard step. To handle this you can use the `getHeaders` function exposed by `register`
+
+```.ts
+export const action = ({ request }) => {
+    const { save, nextStep, jumpToStep, prevStep, getHeaders } =
+      await onboardingWizard.register(request);
+
+    // Here we are adding users to the session on every form submission
+    // Multiple users can be added in this step before we continue to the
+    // next step
+     if (formData.get('intent') === 'addUser') {
+      // Read the existing usrs array from the data object
+      const users = data?.['users'] || [user];
+
+      // Append the new user from the form data to this object
+      const newUser = {
+        email: formData.get('email'),
+        roles: [formData.get('role')],
+      };
+      const newUsers = [...users, newUser];
+
+      save('users', newUsers);
+
+      // The `getHeaders` function is used here to create the appropriate "Set-Cookie" header
+      // that contains the session data
+      return redirect('/onboarding/users', { headers: await getHeaders() });
+    }
+
+    // Go to the next step
+    return nextStep();
+
+}
 ```

--- a/README.md
+++ b/README.md
@@ -97,26 +97,14 @@ export const action = ({ request }) => {
     const { save, nextStep, jumpToStep, prevStep, getHeaders } =
       await onboardingWizard.register(request);
 
-    // Here we are adding users to the session on every form submission
-    // Multiple users can be added in this step before we continue to the
-    // next step
-     if (formData.get('intent') === 'addUser') {
-      // Read the existing usrs array from the data object
-      const users = data?.['users'] || [user];
-
-      // Append the new user from the form data to this object
-      const newUser = {
-        email: formData.get('email'),
-        roles: [formData.get('role')],
-      };
-      const newUsers = [...users, newUser];
-
-      save('users', newUsers);
-
+    if (formData.get("intent") === "stayHere") {
       // The `getHeaders` function is used here to create the appropriate "Set-Cookie" header
-      // that contains the session data
-      return redirect('/onboarding/users', { headers: await getHeaders() });
+      // that contains the session data.
+      const headers = await getHeaders();
+
+      return redirect('/onboarding/users', { headers });
     }
+
 
     // Go to the next step
     return nextStep();

--- a/src/create-wizard.ts
+++ b/src/create-wizard.ts
@@ -28,6 +28,16 @@ export const createWizard = (config: WizardConfig) => {
 
       return {
         data,
+        session,
+        /**
+         * In case you don't want to change the wizard step, but you want to save some data
+         * @returns the headers to set on the response
+         */
+        getHeaders: async () => {
+          const headers = new Headers();
+          headers.append('Set-Cookie', await storage.commitSession(session));
+          return headers;
+        },
         save: (key: string, data: any) => {
           session.set(key, data);
         },

--- a/src/create-wizard.ts
+++ b/src/create-wizard.ts
@@ -29,6 +29,7 @@ export const createWizard = (config: WizardConfig) => {
       return {
         data,
         session,
+        storage,
         /**
          * In case you don't want to change the wizard step, but you want to save some data
          * @returns the headers to set on the response


### PR DESCRIPTION
* In some scenarios you may not always want to change the wizard step in your action. E.G if you are appending form data to the session in a single step.

  * Previously it was not possible to access the Set-Cookie header for this use case, so I have exposed the underlying `session` and added a helper function `getHeaders` which will create the `Set-Cookie` heder with the data in the session